### PR TITLE
CustomDefaultBrowser の iOS 14 対応

### DIFF
--- a/CustomDefaultBrowser/CustomDefaultBrowser/Info.plist
+++ b/CustomDefaultBrowser/CustomDefaultBrowser/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>http</string>
+		<string>https</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## 問題
- iOS 14 ではデフォルトで開くブラウザを変更することができる
- しかし、 `LSApplicationQueriesSchemes` を設定していないと `canOpenURL(_:)` が false を返し、開けないという問題がある

## やったこと
- 上記の問題を修正した
	- `Info.plist` の `LSApplicationQueriesSchemes` という array を追加
	- 中に `http` および `https` を追加して URL を開けるようにした。

## 参考文献
- [iOS 14対応で気をつけるべきこと](https://zenn.dev/tattn/articles/40d1e53cc63d381a3ac5)
- [【iOS14】デフォルトブラウザを変更した時にcanOpenURLがfalseになる問題 - Qiita](https://qiita.com/toto_kit/items/757dfe0a9fddb28eeff5)